### PR TITLE
Add link to project page to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Localization Tools Maven Plugin
 
-The Localization Tools Maven Plugin helps with internationalization and localization of your projects.
+The [Localization Tools Maven Plugin](https://www.mojohaus.org/l10n-maven-plugin) helps with internationalization and localization of your projects.
 
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/mojohaus/mrm.svg?label=License)](http://www.apache.org/licenses/)
 [![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.mojo/l10n-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.mojo/l10n-maven-plugin)


### PR DESCRIPTION
It wasn't immediately obvious where to get more information on the project, unlike [other mojohaus projects](https://github.com/mojohaus/flatten-maven-plugin?tab=readme-ov-file#mojohaus-flatten-maven-plugin).